### PR TITLE
The mime type for the javascript service was causing my app to fail w…

### DIFF
--- a/src/webrender/java/nextapp/echo2/webrender/service/JavaScriptService.java
+++ b/src/webrender/java/nextapp/echo2/webrender/service/JavaScriptService.java
@@ -132,7 +132,7 @@ implements Service {
      */
     private void serviceGZipCompressed(Connection conn) 
     throws IOException {
-        conn.getResponse().setContentType("text/plain");
+        conn.getResponse().setContentType("application/javascript");
         conn.getResponse().setHeader("Content-Encoding", "gzip");
         conn.getOutputStream().write(gzipContent);
     }
@@ -144,7 +144,7 @@ implements Service {
      */
     private void servicePlain(Connection conn) 
     throws IOException {
-        conn.getResponse().setContentType("text/plain");
+        conn.getResponse().setContentType("application/javascript");
         conn.getWriter().print(content);
     }
 }


### PR DESCRIPTION
…ith error "Refused to execute script from serviceId=Echo.ClientEngine because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled." Strict mime type checking happens in a browser when the http header" X-Content-Type-Options: nosniff" is sent with the response. This header is include to help prevent hacks and is part of base configuration for Spring Boot security. After making this change my app works with Firefox 57, Chrome 63, MS IE 11 and MS Edge 41 all on Windows 10.

I don't know if this change will cause a problem with older browsers, from what I've read it seems like old browsers didn't use the Content-Type for scripts.